### PR TITLE
Add multilingual landing page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { LanguageProvider } from "../contexts/LanguageContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <LanguageProvider>{children}</LanguageProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,19 @@
-import Image from "next/image";
+import Header from '../components/Header'
+import HeroSection from '../components/HeroSection'
+import AboutSection from '../components/AboutSection'
+import MenuSection from '../components/MenuSection'
+import ContactSection from '../components/ContactSection'
+import Footer from '../components/Footer'
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className="flex flex-col min-h-screen text-gray-900 bg-orange-50">
+      <Header />
+      <HeroSection />
+      <AboutSection />
+      <MenuSection />
+      <ContactSection />
+      <Footer />
     </div>
-  );
+  )
 }

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,0 +1,11 @@
+'use client'
+import { useLanguage } from '../contexts/LanguageContext'
+
+export default function AboutSection() {
+  const { t } = useLanguage()
+  return (
+    <section id="about" className="max-w-4xl mx-auto py-12 px-4 text-center" >
+      <p>{t('about')}</p>
+    </section>
+  )
+}

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useLanguage } from '../contexts/LanguageContext'
+
+export default function ContactSection() {
+  const { t } = useLanguage()
+  return (
+    <section id="contact" className="py-12 px-4 max-w-4xl mx-auto">
+      <h2 className="text-center text-2xl font-semibold mb-4">{t('contact')}</h2>
+      <form className="flex flex-col gap-4">
+        <input className="border p-2" placeholder={t('name')} />
+        <input className="border p-2" placeholder={t('email')} />
+        <textarea className="border p-2" rows={4} placeholder={t('message')} />
+        <button type="submit" className="bg-purple-500 text-white px-4 py-2 rounded self-start">{t('send')}</button>
+      </form>
+    </section>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="text-center py-4 text-sm text-gray-600">
+      © {new Date().getFullYear()} Panorama Rooftop
+    </footer>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,43 @@
+'use client'
+import Link from 'next/link'
+import { useState } from 'react'
+import { useLanguage } from '../contexts/LanguageContext'
+
+export default function Header() {
+  const { lang, setLang } = useLanguage()
+  const [open, setOpen] = useState(false)
+  const changeLang = (l: typeof lang) => {
+    setLang(l)
+    setOpen(false)
+  }
+
+  return (
+    <header className="sticky top-0 bg-gradient-to-b from-orange-200 to-pink-200 text-gray-900 shadow-md z-10">
+      <div className="max-w-4xl mx-auto flex items-center justify-between p-4">
+        <Link href="/" className="font-bold text-xl">Panorama</Link>
+        <nav className="hidden md:flex gap-4">
+          <Link href="#about">About</Link>
+          <Link href="#menu">Menu</Link>
+          <Link href="#contact">Contact</Link>
+        </nav>
+        <div className="flex gap-2 items-center">
+          <select value={lang} onChange={(e)=>changeLang(e.target.value as any)} className="border rounded px-1 py-0.5 text-sm">
+            <option value="sq">AL</option>
+            <option value="en">EN</option>
+            <option value="it">IT</option>
+          </select>
+          <button className="md:hidden" onClick={()=>setOpen(!open)}>
+            ☰
+          </button>
+        </div>
+      </div>
+      {open && (
+        <nav className="md:hidden flex flex-col items-center gap-2 pb-4">
+          <Link href="#about" onClick={()=>setOpen(false)}>About</Link>
+          <Link href="#menu" onClick={()=>setOpen(false)}>Menu</Link>
+          <Link href="#contact" onClick={()=>setOpen(false)}>Contact</Link>
+        </nav>
+      )}
+    </header>
+  )
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,12 @@
+'use client'
+import { useLanguage } from '../contexts/LanguageContext'
+
+export default function HeroSection() {
+  const { t } = useLanguage()
+  return (
+    <section className="h-[60vh] flex flex-col items-center justify-center text-center bg-gradient-to-b from-orange-300 to-pink-300" id="hero">
+      <h1 className="text-4xl font-bold mb-2 text-gray-900 drop-shadow-lg">{t('title')}</h1>
+      <p className="text-lg text-gray-800">{t('subtitle')}</p>
+    </section>
+  )
+}

--- a/src/components/MenuSection.tsx
+++ b/src/components/MenuSection.tsx
@@ -1,0 +1,14 @@
+'use client'
+import { useLanguage } from '../contexts/LanguageContext'
+
+export default function MenuSection() {
+  const { t } = useLanguage()
+  return (
+    <section id="menu" className="bg-gradient-to-b from-pink-300 to-purple-300 py-12 px-4 text-center">
+      <h2 className="text-2xl font-semibold mb-4">{t('drinks')}</h2>
+      <p>Cocktails, coffee, smoothies, fresh juice, milkshakes</p>
+      <h2 className="text-2xl font-semibold mt-8 mb-4">{t('food')}</h2>
+      <p>Pizza, burgers, crepes</p>
+    </section>
+  )
+}

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,67 @@
+'use client'
+import React, { createContext, useContext, useState } from 'react'
+
+export type Language = 'en' | 'sq' | 'it'
+
+interface LanguageContextProps {
+  lang: Language
+  setLang: (l: Language) => void
+  t: (key: string) => string
+}
+
+const translations: Record<Language, Record<string, string>> = {
+  en: {
+    title: 'Panorama Rooftop',
+    subtitle: 'The best view in Divjaka',
+    about: 'Located on the ninth floor in the center of Divjaka. Enjoy the coastline and the forest from above. Best time of the day is sunset when the atmosphere is cosy and relaxed.',
+    drinks: 'Drinks & Cocktails',
+    food: 'Pizza, Burgers & Crepes',
+    contact: 'Contact Us',
+    name: 'Name',
+    email: 'Email',
+    message: 'Message',
+    send: 'Send'
+  },
+  sq: {
+    title: 'Panorama Rooftop',
+    subtitle: 'Pamja me e mire ne Divjake',
+    about: 'Ndodhet ne katin e nente ne qender te Divjakes. Shijoni vijën bregdetare dhe pyllin nga lart. Koha me e mire per te qendruar eshte perendimi i diellit kur atmosfera eshte shume e rehatsheme.',
+    drinks: 'Pije & Kokteje',
+    food: 'Pizza, Burger & Krepa',
+    contact: 'Na Kontaktoni',
+    name: 'Emri',
+    email: 'Email',
+    message: 'Mesazhi',
+    send: 'Dergo'
+  },
+  it: {
+    title: 'Panorama Rooftop',
+    subtitle: 'La vista migliore di Divjaka',
+    about: 'Situato al nono piano nel centro di Divjaka. Goditi la costa e la foresta dall\'alto. Il momento migliore della giornata è il tramonto quando l\'atmosfera è accogliente.',
+    drinks: 'Bevande & Cocktail',
+    food: 'Pizza, Burger & Crepes',
+    contact: 'Contattaci',
+    name: 'Nome',
+    email: 'Email',
+    message: 'Messaggio',
+    send: 'Invia'
+  }
+}
+
+const LanguageContext = createContext<LanguageContextProps | undefined>(undefined)
+
+export const LanguageProvider = ({ children }: { children: React.ReactNode }) => {
+  const [lang, setLang] = useState<Language>('en')
+  const t = (key: string) => translations[lang][key] || key
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+export const useLanguage = () => {
+  const ctx = useContext(LanguageContext)
+  if (!ctx) throw new Error('useLanguage must be used within LanguageProvider')
+  return ctx
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  content: [
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- implement `LanguageProvider` context for Albanian, English and Italian
- add header with language switcher, mobile menu and homepage logo
- split landing page into `Hero`, `About`, `Menu`, `Contact`, and `Footer` components
- update layout to wrap pages with language provider
- configure Tailwind

## Testing
- `npm run lint` *(fails: `sh: 1: next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861495ecfb8832194190187c3b3d79d