### PR TITLE
Add booking screen with pickup/delivery

### DIFF
--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,0 +1,15 @@
+import Header from '@/components/layout/Header'
+import Footer from '@/components/layout/Footer'
+import BookingScreen from '@/screens/BookingScreen'
+
+export default function BookPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <main>
+        <BookingScreen />
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -21,6 +21,7 @@ export default function Header() {
   const navItems = [
     { href: '/', label: 'Home' },
     { href: '/menu', label: 'Menu' },
+    { href: '/book', label: 'Book' },
     { href: '/contact', label: 'Contact' }
   ]
 

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -18,6 +18,15 @@ const translations: Record<Language, Record<string, string>> = {
     // Hero Section
     viewMenu: 'View Menu',
     bookTable: 'Book Table',
+    bookDescription: 'Book a table, or place an order for pickup or delivery.',
+    dineIn: 'Dine In',
+    pickup: 'Pickup',
+    delivery: 'Delivery',
+    date: 'Date',
+    time: 'Time',
+    guests: 'Guests',
+    orderType: 'Order Type',
+    bookNow: 'Submit',
     
     // About Section
     aboutTitle: 'Experience Divjaka from Above',
@@ -140,6 +149,15 @@ const translations: Record<Language, Record<string, string>> = {
     // Hero Section
     viewMenu: 'Shiko Menune',
     bookTable: 'Rezervo Tavoline',
+    bookDescription: 'Rezervoni një tavolinë ose bëni porosi për të marrë ose për dërgesë.',
+    dineIn: 'Në lokal',
+    pickup: 'Merr vetë',
+    delivery: 'Dërgesë',
+    date: 'Data',
+    time: 'Ora',
+    guests: 'Persona',
+    orderType: 'Lloji i Porosisë',
+    bookNow: 'Dërgo',
     
     // About Section
     aboutTitle: 'Përjetoni Divjakën nga Lart',
@@ -262,6 +280,15 @@ const translations: Record<Language, Record<string, string>> = {
     // Hero Section
     viewMenu: 'Vedi Menu',
     bookTable: 'Prenota Tavolo',
+    bookDescription: 'Prenota un tavolo o effettua un ordine da asporto o con consegna.',
+    dineIn: 'Al tavolo',
+    pickup: 'Asporto',
+    delivery: 'Consegna',
+    date: 'Data',
+    time: 'Ora',
+    guests: 'Persone',
+    orderType: 'Tipo di Ordine',
+    bookNow: 'Invia',
     
     // About Section
     aboutTitle: 'Vivi Divjaka dall\'Alto',

--- a/src/screens/BookingScreen.tsx
+++ b/src/screens/BookingScreen.tsx
@@ -1,0 +1,175 @@
+'use client'
+import { useState } from 'react'
+import { useLanguage } from '@/contexts/LanguageContext'
+
+export default function BookingScreen() {
+  const { t } = useLanguage()
+  const [formData, setFormData] = useState({
+    name: '',
+    phone: '',
+    email: '',
+    guests: 1,
+    date: '',
+    time: '',
+    type: 'dine-in',
+  })
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    console.log('Reservation submitted:', formData)
+  }
+
+  return (
+    <section className="min-h-screen bg-gradient-to-br from-orange-50 to-pink-50 pt-20">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-10">
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">{t('bookTable')}</h1>
+          <div className="w-20 h-1 bg-gradient-to-r from-orange-500 to-pink-500 rounded-full mx-auto mb-6" />
+          <p className="text-lg text-gray-600">{t('bookDescription')}</p>
+        </div>
+        <form onSubmit={handleSubmit} className="bg-white rounded-2xl p-8 shadow-lg space-y-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
+                {t('name')} *
+              </label>
+              <input
+                id="name"
+                name="name"
+                required
+                value={formData.name}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors"
+                placeholder={t('enterName')}
+              />
+            </div>
+            <div>
+              <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-2">
+                {t('phone')} *
+              </label>
+              <input
+                type="tel"
+                id="phone"
+                name="phone"
+                required
+                value={formData.phone}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors"
+                placeholder={t('enterPhone')}
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+              {t('email')}
+            </label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors"
+              placeholder={t('enterEmail')}
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div>
+              <label htmlFor="date" className="block text-sm font-medium text-gray-700 mb-2">
+                {t('date')}
+              </label>
+              <input
+                type="date"
+                id="date"
+                name="date"
+                value={formData.date}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors"
+              />
+            </div>
+            <div>
+              <label htmlFor="time" className="block text-sm font-medium text-gray-700 mb-2">
+                {t('time')}
+              </label>
+              <input
+                type="time"
+                id="time"
+                name="time"
+                value={formData.time}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors"
+              />
+            </div>
+            <div>
+              <label htmlFor="guests" className="block text-sm font-medium text-gray-700 mb-2">
+                {t('guests')}
+              </label>
+              <input
+                type="number"
+                id="guests"
+                name="guests"
+                min="1"
+                value={formData.guests}
+                onChange={handleChange}
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              {t('orderType')}
+            </label>
+            <div className="flex flex-wrap gap-6">
+              <label className="flex items-center space-x-2">
+                <input
+                  type="radio"
+                  name="type"
+                  value="dine-in"
+                  checked={formData.type === 'dine-in'}
+                  onChange={handleChange}
+                  className="accent-orange-500"
+                />
+                <span>{t('dineIn')}</span>
+              </label>
+              <label className="flex items-center space-x-2">
+                <input
+                  type="radio"
+                  name="type"
+                  value="pickup"
+                  checked={formData.type === 'pickup'}
+                  onChange={handleChange}
+                  className="accent-orange-500"
+                />
+                <span>{t('pickup')}</span>
+              </label>
+              <label className="flex items-center space-x-2">
+                <input
+                  type="radio"
+                  name="type"
+                  value="delivery"
+                  checked={formData.type === 'delivery'}
+                  onChange={handleChange}
+                  className="accent-orange-500"
+                />
+                <span>{t('delivery')}</span>
+              </label>
+            </div>
+          </div>
+          <button
+            type="submit"
+            className="w-full bg-gradient-to-r from-orange-500 to-pink-500 text-white py-4 rounded-lg font-semibold hover:from-orange-600 hover:to-pink-600 transform hover:scale-105 transition-all duration-200 shadow-lg"
+          >
+            {t('bookNow')}
+          </button>
+        </form>
+      </div>
+    </section>
+  )
+}

--- a/src/screens/HeroScreen.tsx
+++ b/src/screens/HeroScreen.tsx
@@ -39,7 +39,7 @@ export default function HeroScreen() {
           </Link>
           
           <Link
-            href="/contact"
+            href="/book"
             className="border-2 border-white text-white px-8 py-4 rounded-full font-semibold text-lg hover:bg-white hover:text-gray-900 transition-all duration-200"
           >
             {t('bookTable')}


### PR DESCRIPTION
## Summary
- add `BookingScreen` component with form for dine-in, pickup, or delivery
- create `/book` route using new screen
- link "Book" from navigation and hero CTA
- localize booking strings in all languages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b05be2bc832193ffb5a58e2802ed